### PR TITLE
fix multiple substitutions bug

### DIFF
--- a/src/opentype/GlyphIterator.js
+++ b/src/opentype/GlyphIterator.js
@@ -35,8 +35,8 @@ export default class GlyphIterator {
     return this.glyphs[this.index];
   }
 
-  next() {
-    return this.move(+1);
+  next(count = 1) {
+    return this.move(count);
   }
 
   prev() {

--- a/src/opentype/OTProcessor.js
+++ b/src/opentype/OTProcessor.js
@@ -199,14 +199,16 @@ export default class OTProcessor {
           continue;
         }
 
+        const oldGlyphsLength = glyphs.length
         for (let table of lookup.subTables) {
           let res = this.applyLookup(lookup.lookupType, table);
           if (res) {
             break;
           }
         }
+        const newGlyphsLength = glyphs.length
 
-        this.glyphIterator.next();
+        this.glyphIterator.next(Math.max(1, newGlyphsLength - oldGlyphsLength + 1));
       }
     }
   }


### PR DESCRIPTION
We depend on the fontkit module for generating SVGs font fonts, and we discovered that it's possible to enter an infinite loop when trying to layout a font with multiple substitutions. Basically the GSUBProcessor's applyLookup function can add elements onto this.glyphs, which is a reference to the same array that we use to determine the termination condition of the while loop in OTProcessor's applyLookups.

So the problem is that we can add >1 glyph onto glyphs via applyLookup but we only ever increment this.glyphIterator by 1, which causes this.glyphIterator.index < glyphs.length to always return false.

I don't know if this is the semantically correct fix but it does pass all provided unit tests.